### PR TITLE
Adding a test for strict vs non-strict parsing

### DIFF
--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -1,6 +1,14 @@
+import logging
+import os
+
 from rdflib import Graph
 from rdflib.compare import graph_diff, to_isomorphic
 from units_of_measurement.convert import convert, get_alternative_ucum_code
+
+from pathlib import Path
+
+ROOT = os.path.abspath(os.path.dirname(__file__))
+RESOURCES_DIR = Path(ROOT) / 'resources'
 
 
 def dump_ttl(g):
@@ -10,8 +18,8 @@ def dump_ttl(g):
 
 
 def convert_test(n):
-    input_path = f"tests/resources/test_{n}.txt"
-    output_path = f"tests/resources/test_{n}.ttl"
+    input_path = RESOURCES_DIR / f"test_{n}.txt"
+    output_path = RESOURCES_DIR / f"test_{n}.ttl"
     with open(input_path, "r") as f:
         input_codes = [x.strip() for x in f.readlines()]
     g_actual = convert(input_codes)
@@ -22,15 +30,25 @@ def convert_test(n):
     iso_expected = to_isomorphic(g_expected)
     if iso_actual != iso_expected:
         _, in_first, in_second = graph_diff(iso_actual, iso_expected)
-        print("The actual and expected graphs differ")
+        logging.error("The actual and expected graphs differ")
         if in_first:
-            print("\n----- Contents of actual graph not in expected graph -----")
+            logging.error("\n----- Contents of actual graph not in expected graph -----")
             dump_ttl(in_first)
         if in_second:
-            print("\n----- Contents of expected graph not in actual graph -----")
+            logging.error("\n----- Contents of expected graph not in actual graph -----")
             dump_ttl(in_second)
     assert iso_actual == iso_expected
 
+def test_convert_unsupported():
+    failed_as_expected = False
+    try:
+        convert(['mm[Hg]'], fail_on_err=True)
+    except ValueError as e:
+        logging.info(f'Got expected exception: {e}')
+        failed_as_expected = True
+    assert failed_as_expected
+    g = convert(['mm[Hg]'], fail_on_err=False)
+    assert len(list(g.triples((None, None, None)))) == 0
 
 def test_units():
     for n in range(1, 3):

--- a/units_of_measurement/cli.py
+++ b/units_of_measurement/cli.py
@@ -27,6 +27,12 @@ def main():
     parser.add_argument(
         "-b", "--base-iri", default="https://w3id.org/uom/", help="Base IRI for units"
     )
+    parser.add_argument(
+        "--strict", action='store_true', default=False, help="If strict then throw error on unparseable unit"
+    )
+    parser.add_argument(
+        "--no-strict", action='store_false', help="If no-strict then throw error on unparseable unit"
+    )
     args = parser.parse_args()
 
     outfmt = args.format
@@ -66,6 +72,7 @@ def main():
         mappings,
         lang=args.lang,
         base_iri=args.base_iri,
+        fail_on_err=args.strict,
     )
     if outfmt == "html":
         outstr = graph_to_html(gout)

--- a/units_of_measurement/convert.py
+++ b/units_of_measurement/convert.py
@@ -58,6 +58,7 @@ def convert(
     use_default_mappings: bool = True
 ) -> Graph:
     """
+    Generates an RDF graph seeded from an input list of UCUM codes
 
     :param inputs: list of UCUM codes
     :param ucum_si: UCUM symbol -> dict containing symbol, label, and definition


### PR DESCRIPTION
- fixes #41 
- Added a CLI option for --strict
- Also minor changes to tests to avoid hardcoding paths, this is more portable across IDEs and OSs