### PR TITLE
Add specification

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,30 @@
 # units
 
-`units` converts UCUM codes to linked data. [Initial testing repository](https://github.com/kaiiam/UO_revamp), see `nc_name_script` directory.
+This repo serves two purposes:
+
+- specification for encoding UCUM units as linked data URIs
+- a reference implementation in Python
+
+## Draft Specification
+
+UCUM codes are translated into URIs using the following scheme:
+
+`https://w3id.org/uom/{encode(normalize(code))}`
+
+Here the expression is braces is evaluated using two functions:
+
+- a normalize function (see below)
+- [Percent encoding](https://en.wikipedia.org/wiki/Percent-encoding) rules
+
+For example
+
+- `[diop]` -> https://w3id.org/uom/%5Bdiop%5D
+
+Normalization: There may be multiple ways to write a unit as a UCUM code. The following normalization is first applied:
+
+1. switch / to exponents
+2. sort by exponent, from positive to negative
+3. when the exponent is the same, sort alphabetically
 
 ## Getting Started
 

--- a/README.md
+++ b/README.md
@@ -18,13 +18,14 @@ Here the expression is braces is evaluated using two functions:
 
 For example
 
-- `[diop]` -> https://w3id.org/uom/%5Bdiop%5D
+- `m/s2` -> `m.s-2` -> <https://w3id.org/uom/m.s-2>
+- `[diop]` -> <https://w3id.org/uom/%5Bdiop%5D>
 
 Normalization: There may be multiple ways to write a unit as a UCUM code. The following normalization is first applied:
 
-1. switch / to exponents
-2. sort by exponent, from positive to negative
-3. when the exponent is the same, sort alphabetically
+1. convert `/` (division) to negative exponents
+2. sort parts by exponent, from positive to negative
+3. when the exponent is the same, sort parts alphabetically
 
 ## Getting Started
 


### PR DESCRIPTION
This PR adds a section at the start of the README that makes an initial attempt to separate the *specification* from the *reference implementation*

Addresses:

- #45

Also relevant for:

- https://github.com/biopragmatics/bioregistry/issues/648

